### PR TITLE
Fix gbm_bo_import usage

### DIFF
--- a/main.c
+++ b/main.c
@@ -27,7 +27,7 @@ int main(int argc, char **argv)
     struct _drmModeFB2 *fb;
     uint32_t buffer_id = 0;
 
-    int drm_fd = open("/dev/dri/card1", O_RDWR);
+    int drm_fd = open("/dev/dri/card0", O_RDWR);
     if (drm_fd < 0) {
         log_error("Unable to open DRI device\n");
         exit(1);
@@ -65,109 +65,133 @@ int main(int argc, char **argv)
     fb = drmModeGetFB2(drm_fd, buffer_id);
 
     log_info("Got the framebuffer, id=%d, width=%d, height=%d\n", fb->fb_id, fb->width, fb->height);
+    log_info("DRM handles: %i, %i, %i, %i\n", fb->handles[0], fb->handles[1], fb->handles[2], fb->handles[3]);
 
     /* Check if we have any handles available to us. */
-    int handle_index_check;
-    for (handle_index_check = 0; handle_index_check < 4; handle_index_check++)
+    int num_handles = 0;
+    while (fb->handles[num_handles])
     {
-        if (fb->handles[handle_index_check])
-            break;
+        num_handles++;
     }
-
-    if (handle_index_check == 4) {
+    if (num_handles == 0) {
         log_error("Failed to find a valid handle\n");
         exit(1);
     }
+
+    /* Map GEM handles to prime FDs */
+    struct handle_to_fd
+    {
+        int handle;
+        int fd;
+    };
+    struct handle_to_fd handle_to_fd[4] = {0};
+ 
+    for (int i = 0; i < 4; ++i)
+    {
+        int handle = fb->handles[i];
+        if (handle)
+        {
+            struct handle_to_fd* entry = handle_to_fd;
+            while(entry->handle && (entry->handle != handle))
+            {
+                ++entry;
+            }
+            if (!entry->handle)
+            {
+                entry->handle = handle;
+                int err = drmPrimeHandleToFD(drm_fd, entry->handle, 0, &entry->fd);
+                if (err)
+                {
+                    log_error("Could not get prime fd from handle: %s (%i)\n", strerror(err), err);
+                    exit(EXIT_FAILURE);
+                }
+            }
+        }
+    }
+
             
 
     struct gbm_device* device = gbm_create_device(drm_fd);
 
     /* Output the first image that we find. */
-    for (int handle_index = 0; handle_index < 4 && fb->handles[handle_index]; handle_index++) {
-        int handle_fd;
-        int err = drmPrimeHandleToFD(drm_fd, fb->handles[handle_index], 0, &handle_fd);
-        if (err < 0) {
-            log_error("Could not get prime handle from file descriptor\n");
-            continue;
-        }
-
-        log_info("File Descriptor for the handle is: %d\n", handle_fd);
-        
-        // Establish a memory map.
-        struct gbm_import_fd_data import_data = {
-            handle_fd,
-            fb->width,
-            fb->height,
-            fb->offsets[handle_index],
-            fb->pixel_format};
-        struct gbm_bo* bo = gbm_bo_import(
-            device,
-            GBM_BO_IMPORT_FD,
-            &import_data,
-            0);
-
-        if (!bo)
+    int plane_fds[4] = {0};
+    for (int i = 0; i < num_handles; ++i)
+    {
+        struct handle_to_fd* entry = handle_to_fd;
+        while (entry->handle != fb->handles[i])
         {
-            log_error("gbm_bo_import failed: %d", errno);
-            continue;
+            ++entry;
         }
-
-        void* map_data;
-        uint32_t map_stride;
-        void* void_map = gbm_bo_map(
-            bo,
-            0,
-            0,
-            fb->width,
-            fb->height,
-            0,
-            &map_stride,
-            &map_data);
-
-        if (void_map == MAP_FAILED)
-        {
-            gbm_bo_destroy(bo);
-            log_error("gbm_bo_map failed: %d", errno);
-            continue;
-        }
-
-        unsigned char* map = (unsigned char*)void_map;
-
-        // Initialize the array of pixels
-        unsigned char *img = NULL;
-        int img_size = 3 * fb->width * fb->height;
-        img = (unsigned char *)malloc(img_size);
-        memset(img, 0, img_size);
-
-        // Iterate over the framebuffer and add the pixels to the array.
-        uint32_t size = map_stride * fb->height;
-        uint32_t offset = 0;
-        for (uint32_t y = 0; y < fb->height; y++) {
-            uint32_t read_in_row = 0;
-            for (uint32_t x = 0; x < fb->width; x++) {
-                // Read 32 bits because DRM_FORMAT_XRGB8888
-                unsigned char pixels[4];
-                memcpy(&pixels[0], &map[offset], sizeof(unsigned char) * 4);
-                uint32_t pixel_position = (fb->height - 1 - y) * (3 * fb->width) + (3 * x);
-                img[pixel_position++] = pixels[0];
-                img[pixel_position++] = pixels[1];
-                img[pixel_position++] = pixels[2];
-                read_in_row += sizeof(unsigned char) * 4;
-                offset += sizeof(unsigned char) * 4;
-            }
-            
-            if (read_in_row != fb->pitches[handle_index])
-                log_error("Read the wrong pitch: %d\n", read_in_row);
-        }
-
-        if (offset != size)
-            log_error("Failed to read the entire size!\n");
-
-        generateBitmapImage(img, fb->height, fb->width, (char*)"output.bmp");
-        free(img);
-        gbm_bo_unmap(bo, map_data);
-        gbm_bo_destroy(bo);
+        plane_fds[i] = entry->fd;
     }
+    
+    struct gbm_import_fd_modifier_data import_data = {
+       .width=fb->width,
+       .height=fb->height,
+       .format=fb->pixel_format,
+       .num_fds=num_handles,
+       .fds={plane_fds[0], plane_fds[1], plane_fds[2], plane_fds[3]},
+       .strides={fb->pitches[0], fb->pitches[1], fb->pitches[2], fb->pitches[3]},
+       .offsets={fb->offsets[0], fb->offsets[1], fb->offsets[2], fb->offsets[3]},
+       .modifier=fb->modifier
+    };
+            
+    struct gbm_bo* bo = gbm_bo_import(
+        device,
+        GBM_BO_IMPORT_FD_MODIFIER,
+        &import_data,
+        0);
+
+    if (!bo)
+    {
+        log_error("gbm_bo_import failed: %d", errno);
+        exit(EXIT_FAILURE);
+    }
+
+    void* map_data;
+    uint32_t map_stride;
+    void* void_map = gbm_bo_map(
+        bo,
+        0,
+        0,
+        fb->width,
+        fb->height,
+        GBM_BO_TRANSFER_READ,
+        &map_stride,
+        &map_data);
+
+    if (void_map == MAP_FAILED)
+    {
+        gbm_bo_destroy(bo);
+        log_error("gbm_bo_map failed: %d", errno);
+        exit(EXIT_FAILURE);
+    }
+
+    unsigned char* map = (unsigned char*)void_map;
+
+    // Initialize the array of pixels
+    unsigned char *img = NULL;
+    int img_size = 3 * fb->width * fb->height;
+    img = (unsigned char *)malloc(img_size);
+    memset(img, 0, img_size);
+
+    // Iterate over the framebuffer and add the pixels to the array.
+    for (uint32_t y = 0; y < fb->height; y++) {
+        unsigned char* row = map + (map_stride * y);
+        for (uint32_t x = 0; x < fb->width; x++) {
+            unsigned char* pixel = row + (4 * x);
+            // Read 32 bits because DRM_FORMAT_XRGB8888
+            uint32_t pixel_position = (fb->height - 1 - y) * (3 * fb->width) + (3 * x);
+            img[pixel_position++] = pixel[0];
+            img[pixel_position++] = pixel[1];
+            img[pixel_position++] = pixel[2];
+        }            
+    }
+
+    generateBitmapImage(img, fb->height, fb->width, (char*)"output.bmp");
+    free(img);
+    gbm_bo_unmap(bo, map_data);
+    gbm_bo_destroy(bo);
 
     return 0;
 }


### PR DESCRIPTION
This works on my AMD desktop - notable changes:
* We only import each unique handle once; on my system, GetFB2 returns 3 planes, each with the same handle but differing offsets.
* We use `GBM_BO_IMPORT_FD_MODIFIER`; since we're getting back an FB with a bunch of planes, that's the only way to pass them through
* We call `gbm_bo_map` with `GBM_BO_TRANSFER_READ`, so that the mapping actually has readable contents :wink: 